### PR TITLE
Add easing.scss as the main file on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "sass-easing",
+  "main": "_easings.scss",
   "version": "1.0.2",
   "description": "Easing variables for sass",
   "repository": {


### PR DESCRIPTION
So it can be used on Sass by requiring the module name:

```
@import "sass-easing";
```

You can enable this on the latest version of node-sass:
http://stackoverflow.com/questions/28283652/importing-sass-through-npm/29924381#29924381
